### PR TITLE
Set the same color for the cursor as for the text. Update the width of cursor to 2 points.

### DIFF
--- a/TextAnnotation/Classes/TextContainerView.swift
+++ b/TextAnnotation/Classes/TextContainerView.swift
@@ -123,7 +123,10 @@ open class TextContainerView: NSView {
   
   public var textColor: TextColor {
     set {
-      textView.textColor = NSColor.color(from: newValue)
+      let nsColor = NSColor.color(from: newValue)
+      textView.textColor = nsColor
+      textView.insertionPointColor = nsColor
+
       notifyAboutTextAnnotationUpdates()
     }
     
@@ -175,10 +178,12 @@ open class TextContainerView: NSView {
     textView = TextView(frame: NSRect.zero, responder: self)
     textView.alignment = .natural
     textView.backgroundColor = NSColor.clear
-    textView.textColor = NSColor(red: textColor.red,
-                                 green: textColor.green,
-                                 blue: textColor.blue,
-                                 alpha: textColor.alpha)
+    let nsColor = NSColor(red: textColor.red,
+                          green: textColor.green,
+                          blue: textColor.blue,
+                          alpha: textColor.alpha)
+    textView.textColor = nsColor
+    textView.insertionPointColor = nsColor
     textView.font = NSFont(name: "HelveticaNeue-Bold", size: 30)
     textView.isSelectable = false
     textView.isRichText = false

--- a/TextAnnotation/Classes/TextView.swift
+++ b/TextAnnotation/Classes/TextView.swift
@@ -13,6 +13,8 @@ class TextView: NSTextView {
   
   private weak var activeAreaResponder: MouseTrackingResponder?
   
+  var cursorWidth: CGFloat = 2.0
+  
   // MARK: Private
   
   private var fontSizeToSizeRatio: CGFloat!
@@ -101,6 +103,22 @@ class TextView: NSTextView {
     }
     
     return numberOfLines
+  }
+  
+  // MARK: - Cursor
+  
+  // Taken from here -> https://christiantietze.de/posts/2017/08/nstextview-fat-caret/
+  override func drawInsertionPoint(in rect: NSRect, color: NSColor, turnedOn flag: Bool) {
+    var updatedRect = rect
+    updatedRect.size.width = cursorWidth
+    super.drawInsertionPoint(in: updatedRect, color: color, turnedOn: flag)
+
+  }
+
+  override func setNeedsDisplay(_ rect: NSRect, avoidAdditionalLayout flag: Bool) {
+    var rect = rect
+    rect.size.width += cursorWidth - 1
+    super.setNeedsDisplay(rect, avoidAdditionalLayout: flag)
   }
 }
 


### PR DESCRIPTION
@mirkokiefer 
this is a PR with the completion of task on Basecamp:
**_"Change the text cursor to the font color selected by the user_**"

![cursor_different_color](https://user-images.githubusercontent.com/15073398/91698546-94e8a200-eb7b-11ea-8364-7a219a1e5448.gif)
